### PR TITLE
Allow sites to upgrade to Drush 12, once it is released.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/core-recommended": "^9.2",
         "pantheon-systems/drupal-integrations": "^9",
         "cweagans/composer-patches": "^1.7",
-        "drush/drush": "^11"
+        "drush/drush": "^11 || ^12"
     },
     "require-dev": {
         "drupal/core-dev": "^9.2"


### PR DESCRIPTION
Drush 12 will be coming out in a little bit. (Not immediately -- development hasn't started yet, but I expect it will be a quick release, finished prior to Drupal 10).

The main difference between it and Drush 11 is that Drush 12 won't allow you to bootstrap a Drupal site from a global Drush. (The implication then is that the global Drush is only useful as a launcher, or for commands like "archive:restore", that run without a Drupal site.) That shouldn't matter for site-local Drush instances installed in Pantheon sites. If we do ^11 || ^12 now, then folks will cleanly upgrade to 12 when it is released, and we'll forestall our need to figure out the composer.json conflict problem.