### PR TITLE
[BUGS-5581] Set php_version to a non-EOL version

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -2,7 +2,7 @@ api_version: 1
 web_docroot: true
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional
-php_version: 7.4
+php_version: 8.1
 database:
   version: 10.4
 drush_version: 10

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -99,6 +99,19 @@ class ComposerScripts {
 
       putenv('COMPOSER_ROOT_VERSION=dev-main');
     }
+
+    // Check to see if the platform PHP version (which should be major.minor.patch)
+    // is the same as the Pantheon PHP version (which is only major.minor).
+    // If they do not match, force an update to the platform PHP version. If they
+    // have the same major.minor version, then
+    $platformPhpVersion = static::getCurrentPlatformPhp($event);
+    $pantheonPhpVersion = static::getPantheonPhpVersion($event);
+    $updatedPlatformPhpVersion = static::bestPhpPatchVersion($pantheonPhpVersion);
+    if ((substr($platformPhpVersion, 0, strlen($pantheonPhpVersion)) != $pantheonPhpVersion) && !empty($updatedPlatformPhpVersion)) {
+      $io->write("<info>Setting platform.php from '$platformPhpVersion' to '$updatedPlatformPhpVersion' to conform to pantheon php version.</info>");
+      $cmd = sprintf('composer config platform.php %s', $updatedPlatformPhpVersion);
+      passthru($cmd);
+    }
   }
 
   /**
@@ -127,5 +140,70 @@ class ComposerScripts {
     $cmd = "composer update $versionlessPackagesParam";
     $io->writeError($cmd . PHP_EOL);
     passthru($cmd);
+  }
+
+  /**
+   * Get current platform.php value.
+   */
+  private static function getCurrentPlatformPhp(Event $event) {
+    $composer = $event->getComposer();
+    $config = $composer->getConfig();
+    $platform = $config->get('platform') ?: [];
+    if (isset($platform['php'])) {
+      return $platform['php'];
+    }
+    return null;
+  }
+
+  /**
+   * Get the PHP version from pantheon.yml or pantheon.upstream.yml file.
+   */
+  private static function getPantheonConfigPhpVersion($path) {
+    if (!file_exists($path)) {
+      return null;
+    }
+    if (preg_match('/^php_version:\s?(\d+\.\d+)$/m', file_get_contents($path), $matches)) {
+      return $matches[1];
+    }
+  }
+
+  /**
+   * Get the PHP version from pantheon.yml.
+   */
+  private static function getPantheonPhpVersion(Event $event) {
+    $composer = $event->getComposer();
+    $config = $composer->getConfig();
+    $pantheonYmlPath = $config->get('vendor-dir') . '/../pantheon.yml';
+    $pantheonUpstreamYmlPath = $config->get('vendor-dir') . '/../pantheon.upstream.yml';
+
+    if ($pantheonYmlVersion = static::getPantheonConfigPhpVersion($pantheonYmlPath)) {
+      return $pantheonYmlVersion;
+    } elseif ($pantheonUpstreamYmlVersion = static::getPantheonConfigPhpVersion($pantheonUpstreamYmlPath)) {
+      return $pantheonUpstreamYmlVersion;
+    }
+    return null;
+  }
+
+  /**
+   * Determine which patch version to use when the user changes their platform php version.
+   */
+  private static function bestPhpPatchVersion($pantheonPhpVersion) {
+    // Drupal 10 requires PHP 8.1 at a minimum.
+    // Drupal 9 requires PHP 7.3 at a minimum.
+    // Integrated Composer requires PHP 7.1 at a minimum.
+    $patchVersions = {
+      '8.2' => '8.2.0',
+      '8.1' => '8.1.13',
+      '8.0' => '8.0.26',
+      '7.4' => '7.4.33',
+      '7.3' => '7.3.33',
+      '7.2' => '7.2.34',
+      '7.1' => '7.1.33',
+    }
+    if (isset($patchVersions[$pantheonPhpVersion])) {
+      return $patchVersions[$pantheonPhpVersion];
+    }
+    // This feature is disabled if the user selects an unsupported php version.
+    return '';
   }
 }


### PR DESCRIPTION
This upstream uses php 7.4, but Drupal 9 now requires php 8. [Slack thread](https://pantheon.slack.com/archives/C024NA0Q1TJ/p1669654475241469).

<img width="785" alt="Screenshot at Nov 28 10-46-33" src="https://user-images.githubusercontent.com/17913282/204338405-1274edb8-a16a-4653-828b-67297c9b3b03.png">