### PR TITLE
[CMSP-242] Remove duplicate composer includes in decoupled composer.json

### DIFF
--- a/devops/scripts/decoupledpatch.sh
+++ b/devops/scripts/decoupledpatch.sh
@@ -4,6 +4,12 @@ SED=`which gsed || which sed`
 
 $SED -i'' 's#"name": "pantheon-upstreams/drupal-composer-managed"#"name": "pantheon-upstreams/decoupled-drupal-composer-managed"#g' composer.json
 
+# Due to a line-duplication bug in older versions of the patch script,
+# we'll start by removing any lines containing the decoupled profile packages
+# before adding them back in.
+$SED -i'' '/drupal\/pantheon_decoupled_umami_demo/d' composer.json
+$SED -i'' '/drupal\/pantheon_decoupled_profile/d' composer.json
+
 # Because the precise spacing and formatting is unknown, new lines
 # need to preserve the previous formatting, so here we duplicate the
 # core-recommended line since the new lines need to come afterward,


### PR DESCRIPTION
I had originally come up with a fix that simply avoided re-adding the lines if they were already there, by nesting the `sed` commands in a `grep` to see if they were already there... but that doesn't address the fact that there are already duplicate lines in there now... so, removing all of them and re-adding them is easier than removing all but 1.

Removing and re-adding every time also has the benefit that you can just change what gets added to change them later.